### PR TITLE
Fix : Text preview of cards showed "no content" for cards other than the first

### DIFF
--- a/public/js/card.js
+++ b/public/js/card.js
@@ -340,8 +340,11 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
 
         cssClass = determineCssClass(card)
 
-        card.attr('class', "");
-        cardListEntry.attr('class', "");
+        var colors = ['card-yellow','card-lightgreen','card-purple','card-grey','card-pink','card-green','card-orange','card-blue','card-red','card-lavender','card-buff','card-mint','card-white'];
+        colors.forEach(function(item) {
+            card.removeClass(item)
+            cardListEntry.removeClass(item)
+        });
         
         card.addClass('card').addClass('card-' + cssClass)
         cardListEntry.addClass('card-' + cssClass)

--- a/public/js/card.js
+++ b/public/js/card.js
@@ -232,7 +232,7 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
         $('div.card').each(function(index, card) { $(card).resizable({grid: grid}) });
     }
     Card.prototype.addCardListEntry = function(data) {
-        var content = "<i>No content</i>";
+        var content = '<span class="content">No content</span>';
         if (data.content && (data.content !== '')) {
             content = data.content.substring(0, 30) + '...'
         }
@@ -373,7 +373,7 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
         content = $(this).val();
         content = $(this).val();
         if (content.length == 0) {
-            content = '<i>No content</i>';
+            content = '<span class="content">No content</span>';
         } else {
             content = content.substring(0, 20) + '...';
         }
@@ -382,7 +382,7 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
     socket.on('card.text-change', function(data) {
         $('#' + data.cardId).find('textarea').val(htmlDecode(data.content))
         if (data.content.length == 0) {
-            data.content = "<i>No content</i>";
+            data.content = '<span class="content">No content</span>';
         } else {
             data.content = data.content.substring(0, 20) + '...';
         }

--- a/public/js/card.js
+++ b/public/js/card.js
@@ -232,7 +232,7 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
         $('div.card').each(function(index, card) { $(card).resizable({grid: grid}) });
     }
     Card.prototype.addCardListEntry = function(data) {
-        var content = '<span class="content">No content</span>';
+        var content = "<i>No content</i>";
         if (data.content && (data.content !== '')) {
             content = data.content.substring(0, 30) + '...'
         }
@@ -373,7 +373,7 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
         content = $(this).val();
         content = $(this).val();
         if (content.length == 0) {
-            content = '<span class="content">No content</span>';
+            content = '<i>No content</i>';
         } else {
             content = content.substring(0, 20) + '...';
         }
@@ -382,7 +382,7 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
     socket.on('card.text-change', function(data) {
         $('#' + data.cardId).find('textarea').val(htmlDecode(data.content))
         if (data.content.length == 0) {
-            data.content = '<span class="content">No content</span>';
+            data.content = "<i>No content</i>";
         } else {
             data.content = data.content.substring(0, 20) + '...';
         }

--- a/public/js/card.js
+++ b/public/js/card.js
@@ -340,11 +340,8 @@ define(['jquery', 'socket', 'util/determine-css-class', 'board',
 
         cssClass = determineCssClass(card)
 
-        var colors = ['card-yellow','card-lightgreen','card-purple','card-grey','card-pink','card-green','card-orange','card-blue','card-red','card-lavender','card-buff','card-mint','card-white'];
-        colors.forEach(function(item) {
-            card.removeClass(item)
-            cardListEntry.removeClass(item)
-        });
+        card.attr('class', "");
+        cardListEntry.attr('class', "");
         
         card.addClass('card').addClass('card-' + cssClass)
         cardListEntry.addClass('card-' + cssClass)


### PR DESCRIPTION
It seems the functions which needed to search for the "no content" element used it's class to find it, but these elements had none.